### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ MCP server for GO-CAM model editing via the Barista API.
 
 This package provides a thin MCP (Model Context Protocol) wrapper around the [noctua-py](https://github.com/geneontology/noctua-py) library, exposing GO-CAM editing capabilities through a standardized interface.
 
+<a href="https://glama.ai/mcp/servers/@geneontology/noctua-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@geneontology/noctua-mcp/badge" alt="Noctua Server MCP server" />
+</a>
+
 ## Quick Start
 
 Once published:


### PR DESCRIPTION
This PR adds a badge for the [Noctua MCP Server](https://glama.ai/mcp/servers/@geneontology/noctua-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@geneontology/noctua-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@geneontology/noctua-mcp/badge" alt="Noctua Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.